### PR TITLE
support deltalake 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lakebench"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     { name="Miles Cole" },
 ]
@@ -22,16 +22,14 @@ classifiers = [
 dependencies = [
     "numpy",
     "pyarrow>=15.0.0",
-    "deltalake==0.18.2",
     "sqlglot==26.30.0"
 ]
 
 [project.optional-dependencies]
-duckdb = ["duckdb==1.3.1"]
-polars = ["polars==1.30.0"]
-daft = ["getdaft==0.4.18"]
-all = ["duckdb==1.3.1", "polars==1.30.0", "getdaft==0.4.18"]
-datagen = ["duckdb==1.3.1"]
+duckdb = ["duckdb==1.3.1", "deltalake==1.0.2"]
+polars = ["polars==1.31.0", "deltalake==1.0.2"]
+daft = ["daft==0.5.7", "deltalake==0.25.5"]
+datagen = ["duckb==1.3.1"]
 
 [project.urls]
 github = "https://github.com/mwc360/LakeBench"

--- a/src/lakebench/benchmarks/_tpc/_tpc.py
+++ b/src/lakebench/benchmarks/_tpc/_tpc.py
@@ -174,7 +174,7 @@ class _TPC(BaseBenchmark):
         for table_name in self.TABLE_REGISTRY:
             with self.timer(phase="Load", test_item=table_name, engine=self.engine):
                 self.engine.load_parquet_to_delta(
-                    parquet_folder_path=posixpath.join(self.source_data_path,table_name), 
+                    parquet_folder_path=posixpath.join(self.source_data_path, f"{table_name}/"), 
                     table_name=table_name
                 )
         self.post_results()

--- a/src/lakebench/benchmarks/elt_bench/elt_bench.py
+++ b/src/lakebench/benchmarks/elt_bench/elt_bench.py
@@ -86,9 +86,11 @@ class ELTBench(BaseBenchmark):
             )
         
         if isinstance(engine, Daft):
-            if tpcds_parquet_mount_path is None:
-                raise ValueError("parquet_mount_path must be provided for Daft engine.")
-        self.source_data_path = tpcds_parquet_mount_path or tpcds_parquet_abfss_path
+            if tpcds_parquet_abfss_path is None:
+                raise ValueError("tpcds_parquet_abfss_path must be provided for Daft engine.")
+            self.source_data_path = tpcds_parquet_abfss_path
+        else:
+            self.source_data_path = tpcds_parquet_mount_path or tpcds_parquet_abfss_path
         self.engine = engine
         self.scenario_name = scenario_name
         self.benchmark_impl = self.benchmark_impl_class(
@@ -146,7 +148,7 @@ class ELTBench(BaseBenchmark):
         for table_name in ('store_sales', 'date_dim', 'store', 'item', 'customer'):
             with self.timer(phase="Read parquet, write delta (x5)", test_item=table_name, engine=self.engine):
                 self.engine.load_parquet_to_delta(
-                    parquet_folder_path=posixpath.join(self.source_data_path, table_name), 
+                    parquet_folder_path=posixpath.join(self.source_data_path, f"{table_name}/"), 
                     table_name=table_name
                 )
         with self.timer(phase="Create fact table", test_item='total_sales_fact', engine=self.engine):

--- a/src/lakebench/benchmarks/elt_bench/engine_impl/daft.py
+++ b/src/lakebench/benchmarks/elt_bench/engine_impl/daft.py
@@ -12,24 +12,24 @@ class DaftELTBench:
 
     def create_total_sales_fact(self):
         fact_table_df = (
-            self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'store_sales'))
+            self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'store_sales/'))
             .join(
-                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'date_dim')), 
+                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'date_dim/')), 
                 left_on="ss_sold_date_sk", 
                 right_on="d_date_sk"
             )
             .join(
-                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'store')), 
+                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'store/')), 
                 left_on="ss_store_sk", 
                 right_on="s_store_sk"
             )
             .join(
-                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'item')), 
+                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'item/')), 
                 left_on="ss_item_sk", 
                 right_on="i_item_sk"
             )
             .join(
-                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'customer')), 
+                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'customer/')), 
                 left_on="ss_customer_sk", 
                 right_on="c_customer_sk"
             )
@@ -55,25 +55,25 @@ class DaftELTBench:
     def merge_percent_into_total_sales_fact(self, percent: float):
         
         sampled_fact_data = (
-            self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'store_sales'))
+            self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'store_sales/'))
             .sample(percent)
             .join(
-                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'date_dim')), 
+                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'date_dim/')), 
                 left_on="ss_sold_date_sk", 
                 right_on="d_date_sk"
             )
             .join(
-                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'store')), 
+                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'store/')), 
                 left_on="ss_store_sk", 
                 right_on="s_store_sk"
             )
             .join(
-                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'item')), 
+                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'item/')), 
                 left_on="ss_item_sk", 
                 right_on="i_item_sk"
             )
             .join(
-                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'customer')), 
+                self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'customer/')), 
                 left_on="ss_customer_sk", 
                 right_on="c_customer_sk"
             )
@@ -140,7 +140,7 @@ class DaftELTBench:
 
     def query_total_sales_fact(self):
         query_df = (
-            self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_mount_schema_path, 'total_sales_fact'))
+            self.engine.daft.read_deltalake(posixpath.join(self.engine.delta_abfss_schema_path, 'total_sales_fact/'))
                 .groupby(self.engine.daft.col("sale_date").dt.year())
                 .agg(self.engine.daft.col("total_net_profit").sum().alias("sum_net_profit"))
                 .to_pandas()

--- a/src/lakebench/benchmarks/elt_bench/engine_impl/duckdb.py
+++ b/src/lakebench/benchmarks/elt_bench/engine_impl/duckdb.py
@@ -48,8 +48,7 @@ class DuckDBELTBench:
         self.write_deltalake(
             posixpath.join(self.engine.delta_abfss_schema_path, 'total_sales_fact'),
             arrow_df,
-            mode="overwrite",
-            engine='pyarrow'
+            mode="overwrite"
         )
 
     def merge_percent_into_total_sales_fact(self, percent: float):

--- a/src/lakebench/engines/base.py
+++ b/src/lakebench/engines/base.py
@@ -68,6 +68,5 @@ class BaseEngine(ABC):
         DeltaRs().write_deltalake(
             abfss_path, 
             results_table, 
-            mode="append",
-            engine="rust"
+            mode="append"
         )

--- a/src/lakebench/engines/duckdb.py
+++ b/src/lakebench/engines/duckdb.py
@@ -10,6 +10,7 @@ class DuckDB(BaseEngine):
     SQLGLOT_DIALECT = "duckdb"
     REQUIRED_READ_ENDPOINT = None
     REQUIRED_WRITE_ENDPOINT = "abfss"
+    SUPPORTS_ONELAKE = True
 
     def __init__(
             self, 
@@ -30,8 +31,7 @@ class DuckDB(BaseEngine):
         self.deltars.write_deltalake(
             posixpath.join(self.delta_abfss_schema_path, table_name),
             arrow_df,
-            mode="overwrite",
-            engine='pyarrow'
+            mode="overwrite"
         )  
 
     def register_table(self, table_name: str):

--- a/src/lakebench/engines/polars.py
+++ b/src/lakebench/engines/polars.py
@@ -13,6 +13,7 @@ class Polars(BaseEngine):
     SQLGLOT_DIALECT = "duckdb"
     REQUIRED_READ_ENDPOINT = None
     REQUIRED_WRITE_ENDPOINT = "abfss"
+    SUPPORTS_ONELAKE = True
 
     def __init__(
             self, 

--- a/src/lakebench/engines/spark.py
+++ b/src/lakebench/engines/spark.py
@@ -8,6 +8,7 @@ class Spark(BaseEngine):
     SQLGLOT_DIALECT = "spark"
     REQUIRED_READ_ENDPOINT = None
     REQUIRED_WRITE_ENDPOINT = None
+    SUPPORTS_ONELAKE = True
 
     def __init__(
             self,


### PR DESCRIPTION
- Daft doesn't support Delta-rs 1.0 so I've upgraded it to use the latest working version: 0.25.5. Daft was also no longer working with relative mount paths or OneLake ABFSS so I've changed to use (and require) adls ABFSS paths for Daft.