### PR TITLE
feat: support engine `sail`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ daft = ["daft==0.5.7", "deltalake==0.25.5", "pyarrow>=15.0.0"]
 tpcds_datagen = ["duckdb==1.3.1", "pyarrow>=15.0.0"]
 tpch_datagen = ["duckdb==1.3.1", "pyarrow>=15.0.0"]
 sparkmeasure = ["sparkmeasure==0.24.0"]
+sail_lightweight = ["pysail==0.3.2", "pyspark-client==4.0.0", "deltalake>=1.0.2", "pyarrow>=15.0.0"]
+sail = ["pysail==0.3.2", "pyspark-connect==4.0.0", "deltalake>=1.0.2", "pyarrow>=15.0.0"]
 
 [project.urls]
 github = "https://github.com/mwc360/LakeBench"

--- a/src/lakebench/benchmarks/_load_and_query/_load_and_query.py
+++ b/src/lakebench/benchmarks/_load_and_query/_load_and_query.py
@@ -7,6 +7,7 @@ from ...engines.spark import Spark
 from ...engines.duckdb import DuckDB
 from ...engines.daft import Daft
 from ...engines.polars import Polars
+from ...engines.sail import Sail
 
 import importlib.resources
 import inspect
@@ -21,7 +22,8 @@ class _LoadAndQuery(BaseBenchmark):
         Spark: None,
         DuckDB: None,
         Daft: None,
-        Polars: None
+        Polars: None,
+        Sail: None,
     }
     MODE_REGISTRY = ['load', 'query', 'power_test', 'load_and_query']
     BENCHMARK_NAME = ''
@@ -250,7 +252,7 @@ class _LoadAndQuery(BaseBenchmark):
         if inspect.currentframe().f_back.f_code.co_name not in ('run', '_run_power_test'):
             self.mode = 'query'
 
-        if isinstance(self.engine, (DuckDB, Daft, Polars)):
+        if isinstance(self.engine, (DuckDB, Daft, Polars, Sail)):
             for table_name in self.TABLE_REGISTRY:
                 self.engine.register_table(table_name)
         for query_name in self.query_list:

--- a/src/lakebench/benchmarks/tpcds/tpcds.py
+++ b/src/lakebench/benchmarks/tpcds/tpcds.py
@@ -4,6 +4,7 @@ from ...engines.spark import Spark
 from ...engines.duckdb import DuckDB
 from ...engines.daft import Daft
 from ...engines.polars import Polars
+from ...engines.sail import Sail
 
 class TPCDS(_LoadAndQuery):
     """
@@ -53,7 +54,8 @@ class TPCDS(_LoadAndQuery):
         Spark: None,
         DuckDB: None,
         Daft: None,
-        Polars: None
+        Polars: None,
+        Sail: None,
     }
     BENCHMARK_NAME = 'TPCDS'
     TABLE_REGISTRY = [

--- a/src/lakebench/benchmarks/tpch/tpch.py
+++ b/src/lakebench/benchmarks/tpch/tpch.py
@@ -4,6 +4,7 @@ from ...engines.spark import Spark
 from ...engines.duckdb import DuckDB
 from ...engines.daft import Daft
 from ...engines.polars import Polars
+from ...engines.sail import Sail
 
 class TPCH(_LoadAndQuery):
     """
@@ -49,7 +50,8 @@ class TPCH(_LoadAndQuery):
         Spark: None,
         DuckDB: None,
         Daft: None,
-        Polars: None
+        Polars: None,
+        Sail: None,
     }
     BENCHMARK_NAME = 'TPCH'
     TABLE_REGISTRY = [

--- a/src/lakebench/engines/__init__.py
+++ b/src/lakebench/engines/__init__.py
@@ -5,3 +5,4 @@ from .duckdb import DuckDB
 from .polars import Polars
 from .spark import Spark
 from .fabric_spark import FabricSpark
+from .sail import Sail

--- a/src/lakebench/engines/sail.py
+++ b/src/lakebench/engines/sail.py
@@ -1,0 +1,125 @@
+import os
+import posixpath
+import shutil
+from importlib.metadata import version
+from typing import Optional
+
+from .base import BaseEngine
+from .delta_rs import DeltaRs
+
+
+class Sail(BaseEngine):
+    """
+    Sail Engine for ELT Benchmarks.
+
+    File system support: https://docs.lakesail.com/sail/main/guide/storage/
+    """
+
+    SQLGLOT_DIALECT = "spark"
+    REQUIRED_READ_ENDPOINT = None
+    REQUIRED_WRITE_ENDPOINT = "abfss"
+    SUPPORTS_ONELAKE = True
+    SUPPORTS_SCHEMA_PREP = False
+
+    def __init__(
+        self,
+        delta_abfss_schema_path: str,
+        cost_per_vcore_hour: Optional[float] = None,
+    ):
+        """
+        Initialize the Sail Engine Configs
+        """
+        super().__init__()
+        from pysail.spark import SparkConnectServer
+
+        self.sail_server = SparkConnectServer(port=50051)
+        self.sail_server.start(background=True)
+        sail_server_hostname, sail_server_port = (
+            self.sail_server.listening_address[0],
+            self.sail_server.listening_address[1],
+        )
+
+        from pyspark.sql import SparkSession
+
+        self.spark = SparkSession.builder.remote(
+            f"sc://{sail_server_hostname}:{sail_server_port}"
+        ).getOrCreate()
+        self.spark.conf.set("spark.sql.warehouse.dir", delta_abfss_schema_path)
+
+        self.delta_abfss_schema_path = delta_abfss_schema_path
+        self.deltars = DeltaRs()
+        self.catalog_name = None
+        self.schema_name = None
+
+        if self.delta_abfss_schema_path.startswith("abfss://"):
+            if self.is_fabric:
+                os.environ["AZURE_STORAGE_TOKEN"] = (
+                    self.notebookutils.credentials.getToken("storage")
+                )
+            if not os.getenv("AZURE_STORAGE_TOKEN"):
+                raise ValueError(
+                    "Please store bearer token as env variable `AZURE_STORAGE_TOKEN`"
+                )
+
+        self.version: str = (
+            f"""{version("pysail")} (deltalake=={version("deltalake")})"""
+        )
+        self.cost_per_vcore_hour = cost_per_vcore_hour or getattr(
+            self, "_FABRIC_USD_COST_PER_VCORE_HOUR", None
+        )
+
+    def create_schema_if_not_exists(self, drop_before_create: bool = True):
+        if drop_before_create:
+            if self.is_fabric:
+                try:
+                    self.notebookutils.fs.rm(self.delta_abfss_schema_path, recurse=True)
+                except FileNotFoundError:
+                    pass
+                except Exception as e:
+                    raise e
+            else:
+                shutil.rmtree(self.delta_abfss_schema_path)
+
+    def load_parquet_to_delta(
+        self,
+        parquet_folder_path: str,
+        table_name: str,
+        table_is_precreated: bool = False,
+        context_decorator: Optional[str] = None,
+    ):
+        (
+            self.spark.read.parquet(parquet_folder_path)
+            .write.format("delta")
+            .mode("overwrite")
+            .save(posixpath.join(self.delta_abfss_schema_path, table_name))
+        )
+
+    def register_table(self, table_name: str):
+        """
+        Register a Delta table as temporary view in Sail.
+        """
+        self.spark.read.format("delta").load(
+            posixpath.join(self.delta_abfss_schema_path, table_name)
+        ).createOrReplaceTempView(table_name)
+
+    def execute_sql_query(self, query: str, context_decorator: Optional[str] = None):
+        """
+        Execute a SQL query using Sail.
+        """
+        self.spark.sql(query).collect()
+
+    def optimize_table(self, table_name: str):
+        fact_table = self.deltars.DeltaTable(
+            posixpath.join(self.delta_abfss_schema_path, table_name)
+        )
+        fact_table.optimize.compact()
+
+    def vacuum_table(
+        self, table_name: str, retain_hours: int = 168, retention_check: bool = True
+    ):
+        fact_table = self.deltars.DeltaTable(
+            posixpath.join(self.delta_abfss_schema_path, table_name)
+        )
+        fact_table.vacuum(
+            retain_hours, enforce_retention_duration=retention_check, dry_run=False
+        )


### PR DESCRIPTION
fixes #35
This PR adds support for [sail](https://github.com/lakehq/sail) (that uses [apache datafusion](https://github.com/apache/datafusion)) as another processing engine.
