### PR TITLE
bugfix: refactor generation of spark_history_url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lakebench"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     { name="Miles Cole" },
 ]


### PR DESCRIPTION
Updated spark_history_url to use parsed artifact_id and activity_id from the Spark UI URL as the internal configs used to generate previously have changed